### PR TITLE
upgrade erlang package to erlang version 17.4

### DIFF
--- a/Erlang/erlang.nuspec
+++ b/Erlang/erlang.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>erlang</id>
     <title>Erlang</title>
-    <version>17.3.0</version>
+    <version>17.4.0</version>
     <authors>Joe Armstrong,Robert Virding,Mike Williams</authors>
     <owners>Onorio Catenacci</owners>
     <summary>Erlang/OTP - for building concurrent, distributed, and fault tolerant systems</summary>

--- a/Erlang/tools/chocolateyInstall.ps1
+++ b/Erlang/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 ﻿try {
-	Install-ChocolateyPackage 'erlang' 'EXE' '/S' 'http://www.erlang.org/download/otp_win32_17.3.exe' 'http://www.erlang.org/download/otp_win64_17.3.exe'  -validExitCodes @(0)
+	Install-ChocolateyPackage 'erlang' 'EXE' '/S' 'http://www.erlang.org/download/otp_win32_17.4.exe' 'http://www.erlang.org/download/otp_win64_17.4.exe'  -validExitCodes @(0)
 
   Write-ChocolateySuccess 'Erlang'
 } catch {


### PR DESCRIPTION
Erlang 17.4 contains a patch to SSL handling that I sort of need, so out of self interest it'd be nice to have an updated Chocolatey package.