### PR TITLE
Adding Package Icon

### DIFF
--- a/Rebar/rebar.nuspec
+++ b/Rebar/rebar.nuspec
@@ -9,7 +9,7 @@
     <summary>Erlang build tool.</summary>
     <description>Rebar is an Erlang build tool that makes it easy to compile and test Erlang applications, port drivers and releases.</description>
     <projectUrl>http://www.rebar3.org/</projectUrl>
-    <iconUrl>http://www.rebar3.org/</iconUrl>
+    <iconUrl>http://i.imgur.com/9zCiL6W.png</iconUrl>
     <packageSourceUrl>https://github.com/ElixirWin/ChocolateyPackages</packageSourceUrl>
     <docsUrl>http://www.rebar3.org/v3.0/docs</docsUrl>
     <mailingListUrl>http://www.rebar3.org/discuss</mailingListUrl>


### PR DESCRIPTION
I fixed up the nuspec for Rebar to have a correct link to the project icon which was shared with me by one of the core project committers.
