### PR TITLE
Erlang 18.3 and Fixing The Path For the Elixir Package

### DIFF
--- a/Elixir/Elixir.nuspec
+++ b/Elixir/Elixir.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>elixir</id>
     <title>Elixir</title>
-    <version>1.2.2</version>
+    <version>1.2.3.03182016</version>
     <authors>Jose Valim</authors>
     <owners>Onorio Catenacci</owners>
     <summary>Elixir is a functional meta-programming aware language built on top of the Erlang VM.</summary>

--- a/Elixir/tools/chocolateyInstall.ps1
+++ b/Elixir/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 $package = 'Elixir'
-$version = '1.2.2'
+$version = '1.2.3'
 
 $params = @{
   PackageName = $package;
@@ -18,7 +18,8 @@ Install-ChocolateyZipPackage @params
 $elixirPath = "$env:ChocolateyPackageFolder/bin"
 if (![System.IO.Directory]::Exists($elixirPath)) {$elixirPath = "$env:ChocolateyPackageFolder/bin";}
  
-$env:Path = "$($env:Path);$elixirPath"
+Install-ChocolateyEnvironmentVariable "Path" "$($env:Path);$elixirPath"
+Update-SessionEnvironment
 
 Write-Host @'
 The Elixir commands have been added to your path.

--- a/Erlang/erlang.nuspec
+++ b/Erlang/erlang.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>erlang</id>
     <title>Erlang</title>
-    <version>18.2.1</version>
+    <version>18.3</version>
     <authors>Joe Armstrong,Robert Virding,Mike Williams</authors>
     <owners>Onorio Catenacci</owners>
     <summary>Erlang/OTP - for building concurrent, distributed, and fault tolerant systems</summary>

--- a/Erlang/tools/chocolateyInstall.ps1
+++ b/Erlang/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿$package = 'erlang'
-$version = '18.2.1'
-$erl_version = '7.2.1'
+$version = '18.3'
+$erl_version = '7.3'
 
 Install-ChocolateyPackage $package 'EXE' '/S' http://www.erlang.org/download/otp_win32_$version.exe http://www.erlang.org/download/otp_win64_$version.exe  -validExitCodes @(0)
 

--- a/Erlang/tools/chocolateyUninstall.ps1
+++ b/Erlang/tools/chocolateyUninstall.ps1
@@ -1,6 +1,6 @@
 ﻿$package = 'erlang'
-$version = '18.2.1'
-$erl_version = '7.2.1'
+$version = '18.3'
+$erl_version = '7.3'
 
 start-process -wait "C:\Program Files\erl$erl_version\uninstall.exe"
 

--- a/Rebar/rebar.nuspec
+++ b/Rebar/rebar.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>rebar3</id>
     <title>Rebar3</title>
-    <version>3.0.0-beta4</version>
+    <version>3.0.0</version>
     <authors>Fred Hebert, Tristan Sloughter</authors>
     <owners>Onorio Catenacci</owners>
     <summary>Erlang build tool.</summary>

--- a/Rebar/rebar3.cmd
+++ b/Rebar/rebar3.cmd
@@ -1,9 +1,9 @@
 @echo off
 @call :find_erts_dir
 
-@set rebar_ver=Rebar3-beta4.3.0
+@set rebar_cng_dir=Rebar3
 @set base_cng_dir=/ProgramData/Chocolatey/Lib
-@set rebar_escript_path=%base_cng_dir%/%rebar_ver%
+@set rebar_escript_path=%base_cng_dir%/%rebar_cng_dir%
 for %%r in ("%rebar_escript_path%") do @(set rebar_escript_path=%%~sr)
 
 @%erts_bin_dir%/escript.exe %rebar_escript_path%/rebar3 %*

--- a/Rebar/tools/chocolateyInstall.ps1
+++ b/Rebar/tools/chocolateyInstall.ps1
@@ -1,7 +1,9 @@
 ﻿$package = 'rebar3'
-$version = 'beta.4'
+$version = '3.0.0'
 
 
-Get-ChocolateyWebFile -packageName $package -fileFullPath $env:chocolateyPackageFolder/$package -url "https://github.com/rebar/$package/archive/3.0.0-$version.zip"
+#Get-ChocolateyWebFile -packageName $package -fileFullPath $env:chocolateyPackageFolder/$package -url "https://github.com/rebar/$package/archive/3.0.0-$version.zip"
+
+Get-ChocolateyWebFile -packageName $package -fileFullPath $env:chocolateyPackageFolder/$package -url "https://github.com/rebar/$package/archive/$version.zip"
 
 Install-BinFile "rebar3" -path "$env:chocolateyPackageFolder/rebar3.cmd"

--- a/Rebar/tools/chocolateyUninstall.ps1
+++ b/Rebar/tools/chocolateyUninstall.ps1
@@ -1,5 +1,5 @@
 ﻿$package = 'rebar3'
-$version = 'beta-4'
+$version = '3.0.0'
 
 #Note that this process will _not_ uninstall Erlang.
 #Remove the shim file.


### PR DESCRIPTION
This change includes the new CNG package for Erlang 18.3 and a fix for setting the path in the Elixir package.