### PR TITLE
Don't clobber path during install

### DIFF
--- a/Elixir/tools/chocolateyInstall.ps1
+++ b/Elixir/tools/chocolateyInstall.ps1
@@ -15,10 +15,11 @@ if (!(Test-Path($params.UnzipLocation)))
 
 Install-ChocolateyZipPackage @params
 
-$elixirPath = "$env:ChocolateyPackageFolder/bin"
-if (![System.IO.Directory]::Exists($elixirPath)) {$elixirPath = "$env:ChocolateyPackageFolder/bin";}
- 
-Install-ChocolateyEnvironmentVariable "Path" "$($env:Path);$elixirPath" Machine
+$elixirPath = "$env:ChocolateyPackageFolder\bin"
+if (![System.IO.Directory]::Exists($elixirPath)) {$elixirPath = "$env:ChocolateyPackageFolder\bin";}
+
+$machine_path = [Environment]::GetEnvironmentVariable('Path', 'Machine') 
+Install-ChocolateyEnvironmentVariable "Path" "$($machine_path);$elixirPath" Machine
 Update-SessionEnvironment
 
 Write-Host @'


### PR DESCRIPTION
This fixes #33 

$env:Path includes both the Machine and User Path components, so when we set the Machine we must only append to Machine