### PR TITLE
Update Elixir to 1.5.0

### DIFF
--- a/Elixir/Elixir.nuspec
+++ b/Elixir/Elixir.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>elixir</id>
     <title>Elixir</title>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <authors>Jose Valim</authors>
     <owners>Onorio Catenacci</owners>
     <summary>Elixir is a functional meta-programming aware language built on top of the Erlang VM.</summary>

--- a/Elixir/tools/chocolateyInstall.ps1
+++ b/Elixir/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 $package = 'Elixir'
-$version = '1.4.4'
  
+$version = '1.5.0'
 $params = @{
   PackageName = $package
   FileType = 'zip'
-  CheckSum = '3fc2cc2ec39315d9894a81b9d167029e4a9cfa5bb22edb3d7e0e66971d4e43ed'
+  CheckSum = '01841d8f973e10ea2e8e29342193063efb5ebe2c598c21dc8a3b93ec8428466a'
   CheckSumType = 'sha256'
   Url = "https://github.com/elixir-lang/elixir/releases/download/v$version/Precompiled.zip"
  


### PR DESCRIPTION
Does not require any other changes since this release will still work with Erlang 18. Tried a local pack + upgrade on my machine and it works for me.