### PR TITLE
Add shims for ct_run and typer

### DIFF
--- a/Erlang/tools/chocolateyInstall.ps1
+++ b/Erlang/tools/chocolateyInstall.ps1
@@ -28,9 +28,11 @@ Install-ChocolateyPackage @params
 
 $baseErlangPath = "$env:ProgramFiles/erl$erl_version/erts-$erl_version/bin"
 
+Generate-BinFile "ct_run" -path "$baseErlangPath/ct_run.exe"
 Generate-BinFile "erl" -path "$baseErlangPath/erl.exe"
 Generate-BinFile "werl" -path "$baseErlangPath/werl.exe"
 Generate-BinFile "erlc" -path "$baseErlangPath/erlc.exe"
-Generate-BinFile  "escript" -path "$baseErlangPath/escript.exe"
+Generate-BinFile "escript" -path "$baseErlangPath/escript.exe"
 Generate-BinFile "dialyzer" -path "$baseErlangPath/dialyzer.exe"
+Generate-BinFile "typer" -path "$baseErlangPath/typer.exe"
 

--- a/Erlang/tools/chocolateyUninstall.ps1
+++ b/Erlang/tools/chocolateyUninstall.ps1
@@ -6,8 +6,12 @@ start-process -wait "C:\Program Files\erl$erl_version\uninstall.exe"
 
 #And remove the shim files as well.
 $baseErlangPath = "$env:ProgramFiles/erl$erl_version/erts-$erl_version/bin"
+
+Remove-BinFile "ct_run" -path "$baseErlangPath/ct_run.exe"
 Remove-BinFile "erl" -path "$baseErlangPath/erl.exe"
 Remove-BinFile "werl" -path "$baseErlangPath/werl.exe"
 Remove-BinFile "erlc" -path "$baseErlangPath/erlc.exe"
-Remove-BinFile  "escript" -path "$baseErlangPath/escript.exe"
+Remove-BinFile "escript" -path "$baseErlangPath/escript.exe"
 Remove-BinFile "dialyzer" -path "$baseErlangPath/dialyzer.exe"
+Remove-BinFile "typer" -path "$baseErlangPath/typer.exe"
+


### PR DESCRIPTION
Related to #38.

#38 adds some shims which have since been added - that pull request can be closed.

This pull request adds shims for ct_run.exe and typer.exe. The RabbitMQ team has been updating their test suites to run on Windows, and `ct_run.exe` needs to be in the `PATH`. If Erlang is installed via Chocolatey, it is not in the `PATH` without these shims.