### PR TITLE
Hotfix install & uninstall erlang 23.3

### DIFF
--- a/Erlang/tools/chocolateyInstall.ps1
+++ b/Erlang/tools/chocolateyInstall.ps1
@@ -26,12 +26,12 @@ $params = @{
 
 Install-ChocolateyPackage @params
 
-$baseErlangPath = "$env:ProgramFiles/erl$erl_version/erts-$erl_version/bin"
+$baseErlangPath = "$env:ProgramFiles\erl-$version\erts-$erl_version\bin"
 
-Generate-BinFile "ct_run" -path "$baseErlangPath/ct_run.exe"
-Generate-BinFile "erl" -path "$baseErlangPath/erl.exe"
-Generate-BinFile "werl" -path "$baseErlangPath/werl.exe"
-Generate-BinFile "erlc" -path "$baseErlangPath/erlc.exe"
-Generate-BinFile "escript" -path "$baseErlangPath/escript.exe"
-Generate-BinFile "dialyzer" -path "$baseErlangPath/dialyzer.exe"
-Generate-BinFile "typer" -path "$baseErlangPath/typer.exe"
+Generate-BinFile "ct_run" -path "$baseErlangPath\ct_run.exe"
+Generate-BinFile "erl" -path "$baseErlangPath\erl.exe"
+Generate-BinFile "werl" -path "$baseErlangPath\werl.exe"
+Generate-BinFile "erlc" -path "$baseErlangPath\erlc.exe"
+Generate-BinFile "escript" -path "$baseErlangPath\escript.exe"
+Generate-BinFile "dialyzer" -path "$baseErlangPath\dialyzer.exe"
+Generate-BinFile "typer" -path "$baseErlangPath\typer.exe"

--- a/Erlang/tools/chocolateyUninstall.ps1
+++ b/Erlang/tools/chocolateyUninstall.ps1
@@ -2,16 +2,16 @@
 $version = '23.3'
 $erl_version = '11.2'
 
-start-process -wait "C:\Program Files\erl$erl_version\uninstall.exe /S"
+Start-Process -Wait "$env:ProgramFiles\erl-$version\uninstall.exe" -ArgumentList "/S"
 
 #And remove the shim files as well.
-$baseErlangPath = "$env:ProgramFiles/erl$erl_version/erts-$erl_version/bin"
+$baseErlangPath = "$env:ProgramFiles\erl-$version\erts-$erl_version\bin"
 
-Remove-BinFile "ct_run" -path "$baseErlangPath/ct_run.exe"
-Remove-BinFile "erl" -path "$baseErlangPath/erl.exe"
-Remove-BinFile "werl" -path "$baseErlangPath/werl.exe"
-Remove-BinFile "erlc" -path "$baseErlangPath/erlc.exe"
-Remove-BinFile "escript" -path "$baseErlangPath/escript.exe"
-Remove-BinFile "dialyzer" -path "$baseErlangPath/dialyzer.exe"
-Remove-BinFile "typer" -path "$baseErlangPath/typer.exe"
+Remove-BinFile "ct_run" -path "$baseErlangPath\ct_run.exe"
+Remove-BinFile "erl" -path "$baseErlangPath\erl.exe"
+Remove-BinFile "werl" -path "$baseErlangPath\werl.exe"
+Remove-BinFile "erlc" -path "$baseErlangPath\erlc.exe"
+Remove-BinFile "escript" -path "$baseErlangPath\escript.exe"
+Remove-BinFile "dialyzer" -path "$baseErlangPath\dialyzer.exe"
+Remove-BinFile "typer" -path "$baseErlangPath\typer.exe"
 


### PR DESCRIPTION
While locally testing the package I found that erlang installer have changed the folder name under program files, and that the uninstall was not working, so I fixed both